### PR TITLE
fix: update OAuth2 authentication to use working client_id and PKCE flow

### DIFF
--- a/src/carconnectivity_connectors/audi/auth/audi_web_session.py
+++ b/src/carconnectivity_connectors/audi/auth/audi_web_session.py
@@ -67,7 +67,7 @@ class AudiWebSession(OpenIDSession):
         }
 
         # Set up the web session
-        retries = Retry(total=self.retries, backoff_factor=0.1, status_forcelist=[500], raise_on_status=False)
+        retries = Retry(total=self.retries, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504], raise_on_status=False)
 
         self.websession: requests.Session = requests.Session()
         self.websession.proxies.update(self.proxies)

--- a/src/carconnectivity_connectors/audi/auth/audi_web_session.py
+++ b/src/carconnectivity_connectors/audi/auth/audi_web_session.py
@@ -32,10 +32,10 @@ class AudiWebSession(OpenIDSession):
     """
 
     def __init__(self, session_user, cache, accept_terms_on_login=False, country="DE", language="de", **kwargs):
-        # Audi-specific client_id and redirect_uri (from audi_connect_ha)
-        audi_client_id = "09b6cbec-cd19-4589-82fd-363dfa8c24da@apps_vw-dilab_com"
+        # Audi-specific client_id and redirect_uri (updated to match working ioBroker implementation)
+        audi_client_id = "f4d0934f-32bf-4ce4-b3c4-699a7049ad26@apps_vw-dilab_com"
         audi_redirect_uri = "myaudi:///"
-        audi_scope = "openid email profile vin mbb"
+        audi_scope = "address badge birthdate birthplace email gallery mbb name nationalIdentifier nationality nickname phone picture profession profile vin openid"
         kwargs["client_id"] = audi_client_id
         kwargs["redirect_uri"] = audi_redirect_uri
         kwargs["scope"] = audi_scope
@@ -55,14 +55,14 @@ class AudiWebSession(OpenIDSession):
         self.market_config = None
         self.openid_config = None
 
-        # Dynamic client registration for MBB OAuth
+        # Dynamic client registration for MBB OAuth (updated to match working ioBroker implementation)
         self.client_secret = None
         self.registration_data = {
             "client_name": "CarConnectivity-Python",
             "platform": "android",
             "client_brand": "Audi",
             "appName": "myAudi",
-            "appVersion": "4.31.0",
+            "appVersion": "4.14.1",
             "appId": "de.myaudi.mobile.assistant",
         }
 
@@ -72,16 +72,17 @@ class AudiWebSession(OpenIDSession):
         self.websession: requests.Session = requests.Session()
         self.websession.proxies.update(self.proxies)
         self.websession.mount("https://", HTTPAdapter(max_retries=retries))
-        # Audi-specific user-agent and headers (from audi_connect_ha mobile app pattern)
+        # Audi-specific user-agent and headers (updated to match working ioBroker implementation)
         self.websession.headers = CaseInsensitiveDict(
             {
-                "user-agent": "myAudi-Android/4.31.0 (Android 11; SDK 30)",
+                "user-agent": "myAudi-Android/4.14.1 (Android 11; SDK 30)",
                 "accept": "application/json, text/plain, */*",
                 "accept-language": f"{self.language}-{self.country}, {self.language}; q=0.9",
                 "accept-encoding": "gzip, deflate",
                 "x-requested-with": "de.audi.myaudi",
-                "x-app-version": "4.31.0",
+                "x-app-version": "4.14.1",
                 "x-app-name": "myAudi",
+                "x-client-id": "59edf286-a9ca-4d34-9421-68da00f72dc8",
                 "upgrade-insecure-requests": "1",
             }
         )

--- a/src/carconnectivity_connectors/audi/auth/openid_session.py
+++ b/src/carconnectivity_connectors/audi/auth/openid_session.py
@@ -330,14 +330,28 @@ class OpenIDSession(requests.Session):
             str: The complete authorization URL with the necessary query parameters.
         """
         state = state or self.state
+        # Generate PKCE code verifier and challenge (required for modern OAuth2 flows)
+        import hashlib
+        import base64
+        import secrets
+        code_verifier = secrets.token_urlsafe(64)[:128]  # 128 char code verifier
+        code_challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(code_verifier.encode('ascii')).digest()
+        ).decode('ascii').rstrip('=')
+
+        # Store code_verifier for token exchange
+        self._code_verifier = code_verifier
+
         auth_url = prepare_grant_uri(
             uri=url,
             client_id=self.client_id,
             redirect_uri=self.redirect_uri,
-            response_type="code id_token token",
+            response_type="code",
             scope=self.scope,
             state=state,
             nonce=generate_nonce(),
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
             **kwargs,
         )
         return auth_url
@@ -355,7 +369,7 @@ class OpenIDSession(requests.Session):
         """
         state = state or self.state
 
-        # First try to extract tokens from URL fragment or query parameters (implicit flow)
+        # First try to extract tokens from URL fragment or query parameters
         try:
             from urllib.parse import parse_qs, urlparse
 
@@ -367,13 +381,13 @@ class OpenIDSession(requests.Session):
             if parsed_url.fragment:
                 params_to_parse = parsed_url.fragment
                 source_type = "fragment"
-            elif parsed_url.query and "access_token" in parsed_url.query:
-                # Then try query parameters (converted format: https://egal?token=...)
+            elif parsed_url.query:
+                # Then try query parameters (authorization code flow or converted format)
                 params_to_parse = parsed_url.query
                 source_type = "query"
 
             if params_to_parse:
-                LOG.debug(f"Found {source_type}, parsing implicit flow response")
+                LOG.debug(f"Found {source_type}, parsing authorization response")
                 token_params = parse_qs(params_to_parse)
 
                 # Convert lists to single values (parse_qs returns lists)
@@ -382,9 +396,19 @@ class OpenIDSession(requests.Session):
                     if values:
                         token_data[key] = values[0]
 
-                LOG.debug(f"Extracted token data from {source_type}: {list(token_data.keys())}")
+                LOG.debug(f"Extracted data from {source_type}: {list(token_data.keys())}")
 
-                # Check if we have the required tokens
+                # Check for authorization code flow (code parameter)
+                if "code" in token_data:
+                    LOG.info("Authorization code received, storing for token exchange")
+                    self.token = {
+                        "code": token_data["code"],
+                    }
+                    if "state" in token_data:
+                        self.token["state"] = token_data["state"]
+                    return self.token
+
+                # Check if we have the required tokens (implicit flow)
                 if "access_token" in token_data:
                     # Build proper token structure
                     self.token = {

--- a/src/carconnectivity_connectors/audi/auth/openid_session.py
+++ b/src/carconnectivity_connectors/audi/auth/openid_session.py
@@ -123,11 +123,11 @@ class OpenIDSession(requests.Session):
         """
         self._retries = new_retries_value
         if new_retries_value:
-            # Retry on internal server error (500)
+            # Retry on server errors (500, 502, 503, 504)
             retries = BlacklistRetry(
                 total=new_retries_value,
-                backoff_factor=0.1,
-                status_forcelist=[500],
+                backoff_factor=0.5,
+                status_forcelist=[500, 502, 503, 504],
                 status_blacklist=[429],
                 raise_on_status=False,
             )

--- a/src/carconnectivity_connectors/audi/auth/we_connect_session_audi.py
+++ b/src/carconnectivity_connectors/audi/auth/we_connect_session_audi.py
@@ -382,6 +382,7 @@ class WeConnectSession(AudiWebSession):
             raise AuthenticationError("Refreshing tokens failed: Server requests new authorization")
         if token_response.status_code in (
             requests.codes["internal_server_error"],
+            requests.codes["bad_gateway"],
             requests.codes["service_unavailable"],
             requests.codes["gateway_timeout"],
         ):

--- a/src/carconnectivity_connectors/audi/auth/we_connect_session_audi.py
+++ b/src/carconnectivity_connectors/audi/auth/we_connect_session_audi.py
@@ -37,8 +37,8 @@ class WeConnectSession(AudiWebSession):
         kwargs["cache"] = kwargs.get("cache", {})
         super(WeConnectSession, self).__init__(**kwargs)
 
-        # Force the correct client_id after initialization
-        self.client_id = "09b6cbec-cd19-4589-82fd-363dfa8c24da@apps_vw-dilab_com"
+        # Force the correct client_id after initialization (updated to match working ioBroker implementation)
+        self.client_id = "f4d0934f-32bf-4ce4-b3c4-699a7049ad26@apps_vw-dilab_com"
         self.redirect_uri = "myaudi:///"
 
         LOG.debug(f"WeConnectSession initialized with client_id: {self.client_id}")
@@ -107,17 +107,130 @@ class WeConnectSession(AudiWebSession):
         response = self.do_web_auth(authorization_url_str)
         LOG.debug(f"Web auth completed, got response: {response[:100]}...")
 
-        # Parse tokens directly from the OAuth response
+        # Parse authorization response (may contain code or tokens)
         try:
             self.parse_from_fragment(response)
-            LOG.info("Login successful - tokens obtained from OAuth flow!")
         except Exception as parse_error:
             LOG.error(f"Failed to parse authentication response: {parse_error}")
             LOG.debug(f"Response that failed to parse: {response}")
             raise
 
+        # If we got an authorization code (PKCE flow), exchange it for tokens
+        if self.token and "code" in self.token and "access_token" not in self.token:
+            LOG.info("Authorization code received, exchanging for tokens via PKCE")
+            self._exchange_code_for_tokens()
+
+        if not self.token or "access_token" not in self.token:
+            raise AuthenticationError("Failed to obtain access token from authentication flow")
+
+        LOG.info("Login successful - tokens obtained from OAuth flow!")
+
         # Set the last_login time
         self.last_login = time.time()
+
+    def _exchange_code_for_tokens(self):
+        """Exchange authorization code for tokens using PKCE at Cariad BFF endpoint (like ioBroker)."""
+        if not self.token or "code" not in self.token:
+            raise AuthenticationError("No authorization code available for token exchange")
+
+        if not hasattr(self, "_code_verifier") or not self._code_verifier:
+            raise AuthenticationError("No code_verifier available for PKCE token exchange")
+
+        # Use Cariad BFF endpoint (same as ioBroker) - NOT identity.vwgroup.io
+        token_url = "https://emea.bff.cariad.digital/login/v1/idk/token"
+
+        token_data = {
+            "grant_type": "authorization_code",
+            "code": self.token["code"],
+            "redirect_uri": self.redirect_uri,
+            "client_id": self.client_id,
+            "code_verifier": self._code_verifier,
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        }
+
+        LOG.debug(f"Exchanging code for tokens at {token_url}")
+        LOG.debug(f"Token exchange params: client_id={self.client_id}, redirect_uri={self.redirect_uri}")
+        LOG.debug(f"Token exchange code_verifier length: {len(self._code_verifier)}")
+        try:
+            response = self.websession.post(token_url, data=token_data, headers=headers)
+            response.raise_for_status()
+
+            token_response = response.json()
+            LOG.debug(f"IDK token exchange successful, received keys: {list(token_response.keys())}")
+
+            # Update self.token with the received tokens
+            self.token = {
+                "access_token": token_response["access_token"],
+                "token_type": token_response.get("token_type", "bearer"),
+            }
+
+            if "expires_in" in token_response:
+                self.token["expires_in"] = int(token_response["expires_in"])
+                self.token["expires_at"] = time.time() + int(token_response["expires_in"])
+            if "id_token" in token_response:
+                self.token["id_token"] = token_response["id_token"]
+            if "refresh_token" in token_response:
+                self.token["refresh_token"] = token_response["refresh_token"]
+
+            LOG.info("IDK token exchange completed successfully")
+
+            # Now get Audi-specific token (like ioBroker does)
+            self._get_audi_token()
+
+        except requests.RequestException as e:
+            LOG.error(f"Token exchange failed: {e}")
+            if hasattr(e, "response") and e.response is not None:
+                LOG.error(f"Token exchange error response: {e.response.text}")
+                LOG.error(f"Token exchange response headers: {dict(e.response.headers)}")
+            raise AuthenticationError(f"Failed to exchange authorization code for tokens: {e}") from e
+
+    def _get_audi_token(self):
+        """Exchange IDK token for Audi-specific token (like ioBroker does)."""
+        if not self.token or "access_token" not in self.token:
+            raise AuthenticationError("No access token available for Audi token exchange")
+
+        audi_token_url = "https://emea.bff.cariad.digital/login/v1/audi/token"
+
+        # Use the id_token if available, otherwise use access_token
+        token_to_exchange = self.token.get("id_token", self.token["access_token"])
+
+        token_data = {
+            "token": token_to_exchange,
+            "grant_type": "id_token",
+            "stage": "live",
+            "config": "myaudi",
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.token['access_token']}",
+        }
+
+        LOG.debug(f"Getting Audi token at {audi_token_url}")
+        try:
+            response = self.websession.post(audi_token_url, json=token_data, headers=headers)
+            response.raise_for_status()
+
+            audi_response = response.json()
+            LOG.debug(f"Audi token exchange successful, received keys: {list(audi_response.keys())}")
+
+            # Update token with Audi-specific tokens
+            if "access_token" in audi_response:
+                self.token["audi_access_token"] = audi_response["access_token"]
+            if "id_token" in audi_response:
+                self.token["audi_id_token"] = audi_response["id_token"]
+
+            LOG.info("Audi token exchange completed successfully")
+
+        except requests.RequestException as e:
+            LOG.warning(f"Audi token exchange failed (non-fatal): {e}")
+            if hasattr(e, "response") and e.response is not None:
+                LOG.debug(f"Audi token exchange error response: {e.response.text}")
 
     def refresh(self) -> None:
         # Try refresh tokens from refresh endpoint first

--- a/src/carconnectivity_connectors/audi/connector.py
+++ b/src/carconnectivity_connectors/audi/connector.py
@@ -148,9 +148,11 @@ class Connector(BaseConnector):
         max_age (Optional[int]): Maximum age for cached data in seconds.
     """
 
-    def __init__(self, connector_id: str, car_connectivity: CarConnectivity, config: Dict) -> None:
+    def __init__(self, connector_id: str, car_connectivity: CarConnectivity, config: Dict,
+                 initialization: Optional[Dict] = None, **kwargs) -> None:
         BaseConnector.__init__(
-            self, connector_id=connector_id, car_connectivity=car_connectivity, config=config, log=LOG, api_log=LOG_API
+            self, connector_id=connector_id, car_connectivity=car_connectivity, config=config,
+            initialization=initialization, log=LOG, api_log=LOG_API
         )
 
         self._background_thread: Optional[threading.Thread] = None

--- a/src/carconnectivity_connectors/audi/vehicle.py
+++ b/src/carconnectivity_connectors/audi/vehicle.py
@@ -77,9 +77,11 @@ class AudiVehicle(GenericVehicle):  # pylint: disable=too-many-instance-attribut
         garage: Optional[Garage] = None,
         managing_connector: Optional[BaseConnector] = None,
         origin: Optional[AudiVehicle] = None,
+        initialization: Optional[Dict] = None,
+        **kwargs,
     ) -> None:
         if origin is not None:
-            super().__init__(garage=garage, origin=origin)
+            super().__init__(garage=garage, origin=origin, initialization=initialization, **kwargs)
             self.capabilities: Capabilities = origin.capabilities
             self.capabilities.parent = self
             self.is_active: BooleanAttribute = origin.is_active
@@ -89,7 +91,7 @@ class AudiVehicle(GenericVehicle):  # pylint: disable=too-many-instance-attribut
             if SUPPORT_IMAGES:
                 self._car_images = origin._car_images
         else:
-            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector)
+            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization, **kwargs)
             self.capabilities: Capabilities = Capabilities(vehicle=self)
             self.climatization = AudiClimatization(vehicle=self, origin=self.climatization)
             self.is_active = BooleanAttribute(name="is_active", parent=self, tags={"connector_custom"})
@@ -124,12 +126,14 @@ class AudiElectricVehicle(ElectricVehicle, AudiVehicle):
         garage: Optional[Garage] = None,
         managing_connector: Optional[BaseConnector] = None,
         origin: Optional[AudiVehicle] = None,
+        initialization: Optional[Dict] = None,
+        **kwargs,
     ) -> None:
         # Initialize parent classes through MRO - always call super().__init__()
         # CodeQL requires this call to be made in all code paths
         if origin is not None:
             # Initialize with origin-based parameters
-            super().__init__(garage=garage, origin=origin)
+            super().__init__(garage=garage, origin=origin, initialization=initialization, **kwargs)
             # Set up Audi-specific charging with origin
             if isinstance(origin, ElectricVehicle):
                 self.charging = AudiCharging(vehicle=self, origin=origin.charging)
@@ -137,7 +141,7 @@ class AudiElectricVehicle(ElectricVehicle, AudiVehicle):
                 self.charging = AudiCharging(vehicle=self, origin=self.charging)
         else:
             # Initialize with direct parameters
-            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector)
+            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization, **kwargs)
             # Set up Audi-specific charging without origin
             self.charging = AudiCharging(vehicle=self, origin=self.charging)
 
@@ -167,15 +171,17 @@ class AudiCombustionVehicle(CombustionVehicle, AudiVehicle):
         garage: Optional[Garage] = None,
         managing_connector: Optional[BaseConnector] = None,
         origin: Optional[AudiVehicle] = None,
+        initialization: Optional[Dict] = None,
+        **kwargs,
     ) -> None:
         # Initialize parent classes through MRO - always call super().__init__()
         # CodeQL requires this call to be made in all code paths
         if origin is not None:
             # Initialize with origin-based parameters
-            super().__init__(garage=garage, origin=origin)
+            super().__init__(garage=garage, origin=origin, initialization=initialization, **kwargs)
         else:
             # Initialize with direct parameters
-            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector)
+            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization, **kwargs)
 
 
 class AudiHybridVehicle(HybridVehicle, AudiElectricVehicle, AudiCombustionVehicle):
@@ -207,12 +213,14 @@ class AudiHybridVehicle(HybridVehicle, AudiElectricVehicle, AudiCombustionVehicl
         garage: Optional[Garage] = None,
         managing_connector: Optional[BaseConnector] = None,
         origin: Optional[AudiVehicle] = None,
+        initialization: Optional[Dict] = None,
+        **kwargs,
     ) -> None:
         # Initialize parent classes through MRO - always call super().__init__()
         # CodeQL requires this call to be made in all code paths
         if origin is not None:
             # Initialize with origin-based parameters
-            super().__init__(garage=garage, origin=origin)
+            super().__init__(garage=garage, origin=origin, initialization=initialization, **kwargs)
         else:
             # Initialize with direct parameters
-            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector)
+            super().__init__(vin=vin, garage=garage, managing_connector=managing_connector, initialization=initialization, **kwargs)


### PR DESCRIPTION
The authentication was failing with HTTP 400 because the client_id was no longer valid. This fix updates the authentication to match the working ioBroker VW-Connect implementation:

Authentication changes:
- Update client_id to f4d0934f-32bf-4ce4-b3c4-699a7049ad26@apps_vw-dilab_com
- Implement PKCE (Proof Key for Code Exchange) with S256 challenge
- Use authorization code flow instead of implicit flow
- Exchange code for tokens at Cariad BFF endpoint (emea.bff.cariad.digital)
- Update app version headers to 4.14.1
- Add x-client-id header

Compatibility fixes for carconnectivity 0.11.5:
- Add initialization parameter to Connector.__init__()
- Add initialization parameter to all vehicle classes

Tested successfully with real Audi Connect account.